### PR TITLE
chore: version bump to fix vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,12 +13,12 @@
     "build": "rimraf dist && ui5 build --a"
   },
   "devDependencies": {
-    "@ui5/cli": "^2.14.2",
-    "eslint": "^8.6.0",
-    "karma": "^6.3.10",
-    "karma-chrome-launcher": "^3.1.0",
-    "karma-coverage": "^2.1.0",
-    "karma-ui5": "^2.4.0",
-    "rimraf": "^3.0.2"
+    "@ui5/cli": "^3.6.1",
+    "eslint": "^8.50.0",
+    "karma": "^6.4.2",
+    "karma-chrome-launcher": "^3.2.0",
+    "karma-coverage": "^2.2.1",
+    "karma-ui5": "^3.0.3",
+    "rimraf": "^5.0.5"
   }
 }

--- a/ui5.yaml
+++ b/ui5.yaml
@@ -1,10 +1,10 @@
-specVersion: '2.6'
+specVersion: '3.1'
 metadata:
   name: openui5-basic-template-app
 type: application
 framework:
   name: OpenUI5
-  version: "1.96.2"
+  version: "1.119.0"
   libraries:
     - name: sap.m
     - name: sap.ui.core


### PR DESCRIPTION
Bump outdated versions to current ones to fix vulnerabilities. Deprecation is not yet merged to master. Code should be secure before deprecation.